### PR TITLE
Fix crash when _html is bytes and not str

### DIFF
--- a/evernote_dump/note_parser/note.py
+++ b/evernote_dump/note_parser/note.py
@@ -51,7 +51,7 @@ class Note(object):
         self._attributes.append([attr, dataline])
 
     def append_html(self, text):
-        self._html += text
+        self._html = str(self._html) + text
 
     def append_tag(self, tag):
         self._tags.append(tag)


### PR DESCRIPTION
Happened while I exported my notes. Not sure how _html can be bytes and not str....

```
  File "/Users/me/src/foreign/evernote-dump/evernote_dump/note_parser/note.py", line 55, in append_html
    self._html += text
TypeError: can't concat str to bytes
```