### PR TITLE
Add support for note titles that sax streams in more than one chunk

### DIFF
--- a/evernote_dump/note_parser/note.py
+++ b/evernote_dump/note_parser/note.py
@@ -50,6 +50,9 @@ class Note(object):
     def add_found_attribute(self, attr, dataline):
         self._attributes.append([attr, dataline])
 
+    def append_title(self, text):
+        self._title = str(self._title) + text
+
     def append_html(self, text):
         self._html = str(self._html) + text
 
@@ -175,6 +178,7 @@ class Note(object):
         self._markdown += tags
 
     def finalize(self):
+        self.create_filename()
         self.create_markdown()
 
     def get_created_date(self):
@@ -207,6 +211,3 @@ class Note(object):
     def set_path(self, path):
         self._path = path
 
-    def set_title(self, title):
-        self._title = title
-        self.create_filename()

--- a/evernote_dump/note_parser/note_parser.py
+++ b/evernote_dump/note_parser/note_parser.py
@@ -80,7 +80,7 @@ class NoteParser(ContentHandler):
     def characters(self, content_stream):
         """Content Stream"""
         if self.CurrentData == "title":
-            self.note.set_title(content_stream)
+            self.note.append_title(content_stream)
         elif self.CurrentData == "content":
             self.note.append_html(content_stream)
         elif self.CurrentData == "created":

--- a/test/test_evernote_dump.py
+++ b/test/test_evernote_dump.py
@@ -15,6 +15,13 @@ class TestEvernoteDump(unittest.TestCase):
 
     # TODO: Add test for preserved file names
 
+    def test_run_parse_filename_match_note_title(self):
+        self.s.files = ['data/Recipes.enex', ]
+        self.s.n = True
+        dump.run_parse(self.s)
+        self.assertTrue(os.path.isfile(("Recipes/Healthy Recipe From Joy Bauer's Food Cures Light Balsamic Vinaigrette.md")))
+        shutil.rmtree('Recipes')
+
     def test_run_parse_single_file_with_out_overwrite(self):
         self.s.files = ['data/Archives.enex']
         dump.run_parse(self.s)


### PR DESCRIPTION
Found bug in how NoteParser.characters handles the title. While xml.sax will stream contents, the title is being handled with an explicit setting each time.

This appears to cause problems when the .enex file has a note with a title containing an apostrophe (i.e., &pos;). The stream gets broken up into chunks of (1) before the apostrophe, (2) the apostrophe, and (3) after the apostrophe. As such, when using the title for a filename, only the third chunk becomes the filename.

To fix this:
- note.py's Note class: Add append_title method, remove the set_title method, and move the call to create_filename into the finalize method.
- note_parser.py's NoteParser class: Change characters method to use Note.append_title instead of Note.set_title.

To verify this fix:
- The example Recipes.enex has notes whose titles include apostrophes.
- Add unittest test_run_parse_filename_match_note_title to fail when 1 exported recipe note file, whose title should include an apostrophe, does not exist.